### PR TITLE
Changes default terminal name

### DIFF
--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -49,7 +49,7 @@ public class Preferences : Gtk.Dialog {
             }
 
             if(terminalNameEntry.text ==  ""){
-                settings.set_string ("terminalname", "pantheon-terminal");
+                settings.set_string ("terminalname", "io.elementary.terminal");
             }else{
                 settings.set_string("terminalname", terminalNameEntry.text);
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -17,7 +17,7 @@ public class MainWindow : Gtk.Window{
            settings.set_string ("sshname", Environment.get_user_name ());
         }
         if(settings.get_string ("terminalname") == ""){
-           settings.set_string ("terminalname", "pantheon-terminal");
+           settings.set_string ("terminalname", "io.elementary.terminal");
         }
 
         set_default_size(Constants.APPLICATION_WIDTH, Constants.APPLICATION_HEIGHT);


### PR DESCRIPTION
In elementary OS Loki, released today, executing `pantheon-terminal` will not start the terminal. The terminal has been renamed to `io.elementary.terminal` and this pull request reflects that change.