### PR TITLE
Fix io.elementary.vala-lint errors

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -70,4 +70,3 @@ public class App:Granite.Application {
     }
 }
 }
-

--- a/src/Components/BookmarkForm.vala
+++ b/src/Components/BookmarkForm.vala
@@ -18,9 +18,9 @@ public class BookmarkForm : Gtk.Grid {
         var host_label = new BookmarkFormLabel (_("Host:*"));
         var hostname_label = new BookmarkFormLabel (_("Host name:*"));
         var username_label = new BookmarkFormLabel (_("Username:"));
-        var portLabel = new BookmarkFormLabel (_("Port:"));
+        var port_label = new BookmarkFormLabel (_("Port:"));
         var agent_forward_label = new BookmarkFormLabel (_("Use agent forwarding:"));
-        var proxy_commandLabel = new BookmarkFormLabel (_("Proxy command:"));
+        var proxy_command_label = new BookmarkFormLabel (_("Proxy command:"));
 
         button_box.set_layout (Gtk.ButtonBoxStyle.END);
         button_box.set_margin_start (12);
@@ -40,11 +40,11 @@ public class BookmarkForm : Gtk.Grid {
         attach (host_name_entry, 1, 3, 1, 1);
         attach (username_label, 0, 4, 1, 1);
         attach (username_entry, 1, 4, 1, 1);
-        attach (portLabel, 0, 5, 1, 1);
+        attach (port_label, 0, 5, 1, 1);
         attach (port_entry, 1, 5, 1, 1);
         attach (agent_forward_label, 0, 6, 1, 1);
         attach (agent_forward_check_button, 1, 6, 1, 1);
-        attach (proxy_commandLabel, 0, 7, 1, 1);
+        attach (proxy_command_label, 0, 7, 1, 1);
         attach (proxy_command_entry, 1, 7, 1, 1);
 
         attach (button_box, 1, 8, 1, 1);

--- a/src/ConfigFileReader.vala
+++ b/src/ConfigFileReader.vala
@@ -170,36 +170,36 @@ public class ConfigFileReader : Object {
     }
 
     public string get_filtered_value (string[] splitted_line) {
-        var elementsCount = 0;
-        string filteredValue = "";
+        var elements_count = 0;
+        string filtered_value = "";
         foreach (string part in splitted_line) {
             if (part == "") {
                 continue;
             }
 
-            if (elementsCount == 0 ) {
-                elementsCount++;
+            if (elements_count == 0 ) {
+                elements_count++;
                 continue;
             }
 
-            if (elementsCount == 1 ) {
-                filteredValue += part;
-                elementsCount++;
+            if (elements_count == 1 ) {
+                filtered_value += part;
+                elements_count++;
                 continue;
             }
 
-            filteredValue += " " + part;
+            filtered_value += " " + part;
         }
-        return filteredValue;
+        return filtered_value;
     }
 
     private File get_ssh_config_file () {
         string path = Environment.get_home_dir ();
 
-        var sshFolder = File.new_for_path (path + "/.ssh/");
-        if (!sshFolder.query_exists ()) {
+        var ssh_folder = File.new_for_path (path + "/.ssh/");
+        if (!ssh_folder.query_exists ()) {
             try {
-                sshFolder.make_directory ();
+                ssh_folder.make_directory ();
             } catch (Error e) {
                 error ("%s", e.message);
             }
@@ -215,10 +215,10 @@ public class ConfigFileReader : Object {
             }
         }
 
-        var backupFile = File.new_for_path (path + "/.ssh/config_backup");
-        if (!backupFile.query_exists ()) {
+        var backup_file = File.new_for_path (path + "/.ssh/config_backup");
+        if (!backup_file.query_exists ()) {
             try {
-                file.copy (backupFile, 0, null);
+                file.copy (backup_file, 0, null);
             } catch (Error e) {
                 error ("%s", e.message);
             }
@@ -232,15 +232,15 @@ public class ConfigFileReader : Object {
 
         try {
             if (file.query_exists () == true) {
-                var otherSettings = get_other_settings ();
-                string bookmarksRaw = convert_bookmarks_to_string (bookmarks);
-                var otherSettingsRaw = convert_other_settings_to_string (otherSettings);
+                var other_settings = get_other_settings ();
+                string bookmarks_raw = convert_bookmarks_to_string (bookmarks);
+                var other_settings_raw = convert_other_settings_to_string (other_settings);
 
                 file.delete (null);
                 FileOutputStream fos = file.create (FileCreateFlags.REPLACE_DESTINATION, null);
                 DataOutputStream dos = new DataOutputStream (fos);
 
-                dos.put_string (otherSettingsRaw + bookmarksRaw, null);
+                dos.put_string (other_settings_raw + bookmarks_raw, null);
             }
         } catch (Error e) {
             stderr.printf ("Error: %s\n", e.message);
@@ -248,26 +248,26 @@ public class ConfigFileReader : Object {
     }
 
     private string convert_other_settings_to_string (string[] settings) {
-        string rawSettingsString = "";
+        string raw_settings_string = "";
 
         foreach (string setting in settings) {
-            string rawSetting = setting + "\n";
-            rawSettingsString += rawSetting;
+            string raw_setting = setting + "\n";
+            raw_settings_string += raw_setting;
         }
 
-        rawSettingsString += "\n";
-        return rawSettingsString;
+        raw_settings_string += "\n";
+        return raw_settings_string;
     }
 
     private string convert_bookmarks_to_string (Bookmark[] bookmarks) {
-        string raw_bookmarksString = "";
+        string raw_bookmarks_string = "";
 
         foreach (Bookmark bookmark in bookmarks) {
             string raw_bookmark = convert_bookmark_to_string (bookmark);
-            raw_bookmarksString += raw_bookmark;
+            raw_bookmarks_string += raw_bookmark;
         }
 
-        return raw_bookmarksString;
+        return raw_bookmarks_string;
     }
 
     private string convert_bookmark_to_string (Bookmark bookmark) {

--- a/src/DesktopFileManager/DesktopFileApplication.vala
+++ b/src/DesktopFileManager/DesktopFileApplication.vala
@@ -15,4 +15,3 @@ public class App:Application {
     }
 }
 }
-

--- a/src/DesktopFileManager/DesktopFileManager.vala
+++ b/src/DesktopFileManager/DesktopFileManager.vala
@@ -4,19 +4,19 @@ public class DesktopFileManager {
     private Settings settings = new Settings ("com.github.bartzaalberg.bookmark-manager");
 
     public File get_backup_desktop_config_file () {
-        var backupFile = File.new_for_path (
+        var backup_file = File.new_for_path (
             "/usr/share/applications/com.github.bartzaalberg.bookmark-manager.backup"
         );
-        if (!backupFile.query_exists ()) {
+        if (!backup_file.query_exists ()) {
             try {
                 var normal_file = get_desktop_config_file ();
-                normal_file.copy (backupFile, 0, null);
+                normal_file.copy (backup_file, 0, null);
                 get_backup_desktop_config_file ();
             } catch (Error e) {
                 error ("%s", e.message);
             }
         }
-        return backupFile;
+        return backup_file;
     }
 
     public File get_desktop_config_file () {
@@ -34,8 +34,8 @@ public class DesktopFileManager {
 
     public void write_to_desktop_file (Bookmark[] bookmarks) {
 
-        var backupFile = get_backup_desktop_config_file ();
-        var lines = new DataInputStream (backupFile.read ());
+        var backup_file = get_backup_desktop_config_file ();
+        var lines = new DataInputStream (backup_file.read ());
         var normal_file = get_desktop_config_file ();
         var desktop_bookmarks_raw = "";
         string line;
@@ -65,39 +65,39 @@ public class DesktopFileManager {
     }
 
     private string convert_bookmarks_to_desktop_file_string (Bookmark[] bookmarks) {
-        string raw_bookmarksString = "";
+        string raw_bookmarks_string = "";
 
         foreach (Bookmark bookmark in bookmarks) {
             string raw_bookmark = generate_ssh_command (bookmark);
-            raw_bookmarksString += raw_bookmark;
+            raw_bookmarks_string += raw_bookmark;
         }
 
-        return raw_bookmarksString;
+        return raw_bookmarks_string;
     }
 
     private string convert_bookmarks_to_actions_string (Bookmark[] bookmarks) {
-        string raw_bookmarksString = "Actions=AboutDialog;";
+        string raw_bookmarks_string = "Actions=AboutDialog;";
 
         foreach (Bookmark bookmark in bookmarks) {
-            raw_bookmarksString += bookmark.get_name () + ";";
+            raw_bookmarks_string += bookmark.get_name () + ";";
         }
 
-        return raw_bookmarksString;
+        return raw_bookmarks_string;
     }
 
     public string generate_ssh_command (Bookmark bookmark) {
         var username = settings.get_string ("sshname");
-        var terminalName = settings.get_string ("terminalname");
+        var terminal_name = settings.get_string ("terminalname");
         if (bookmark.get_user () != null && bookmark.get_user () != "") {
             username = bookmark.get_user ();
         }
 
-        var actionString = "[Desktop Action " + bookmark.get_name () + "]\n";
-        actionString += "Name=ssh " + bookmark.get_name () + "\n";
-        actionString += "Exec=" + terminalName + " --execute='ssh " + username + "@" + bookmark.get_name () + "'\n";
-        actionString += "\n";
+        var action_string = "[Desktop Action " + bookmark.get_name () + "]\n";
+        action_string += "Name=ssh " + bookmark.get_name () + "\n";
+        action_string += "Exec=" + terminal_name + " --execute='ssh " + username + "@" + bookmark.get_name () + "'\n";
+        action_string += "\n";
 
-        return actionString;
+        return action_string;
     }
 }
 }

--- a/src/Dialogs/Cheatsheet.vala
+++ b/src/Dialogs/Cheatsheet.vala
@@ -48,14 +48,14 @@ public class Cheatsheet : Gtk.Dialog {
         grid.margin = 12;
         grid.attach (general_header, 0, 0, 2, 1);
 
-        var gridPosition = 1;
+        var grid_position = 1;
         var index = 0;
 
         foreach (Gtk.Label shortcut in shortcuts) {
-            grid.attach (labels[index], 0, gridPosition, 1, 1);
-            grid.attach (shortcuts[index], 1, gridPosition, 1, 1);
+            grid.attach (labels[index], 0, grid_position, 1, 1);
+            grid.attach (shortcuts[index], 1, grid_position, 1, 1);
 
-            gridPosition++;
+            grid_position++;
             index++;
         }
 

--- a/src/Dialogs/DeleteConfirm.vala
+++ b/src/Dialogs/DeleteConfirm.vala
@@ -24,15 +24,15 @@ public class DeleteConfirm : Object {
     private void delete_bookmark (Bookmark deleted_bookmark) {
         var config_file_reader = new ConfigFileReader ();
         var bookmarks = config_file_reader.get_bookmarks ();
-        Bookmark[] new_bookmarksList = {};
+        Bookmark[] new_bookmarks_list = {};
 
         foreach (Bookmark bookmark in bookmarks) {
            if (bookmark.get_name () != deleted_bookmark.get_name ()) {
-                new_bookmarksList += bookmark;
+                new_bookmarks_list += bookmark;
            }
         }
 
-        config_file_reader.write_to_file (new_bookmarksList);
+        config_file_reader.write_to_file (new_bookmarks_list);
 
         stack_manager.get_stack ().visible_child_name = "list-view";
         list_box.get_bookmarks ("");

--- a/src/Dialogs/Preferences.vala
+++ b/src/Dialogs/Preferences.vala
@@ -11,7 +11,7 @@ public class Preferences : Gtk.Dialog {
 
         var general_header = new HeaderLabel (_("Preferences"));
 
-        var usernameLabel = generate_label (_("Default Username:"));
+        var username_label = generate_label (_("Default Username:"));
 
         var username_entry = new Gtk.Entry ();
         username_entry.set_text (settings.get_string ("sshname"));
@@ -86,7 +86,7 @@ public class Preferences : Gtk.Dialog {
         general_grid.column_spacing = 12;
         general_grid.margin = 12;
         general_grid.attach (general_header, 0, 0, 2, 1);
-        general_grid.attach (usernameLabel, 0, 1, 1, 1);
+        general_grid.attach (username_label, 0, 1, 1, 1);
         general_grid.attach (username_entry, 1, 1, 1, 1);
 
         general_grid.attach (terminal_name_label, 0, 2, 1, 1);

--- a/src/ListBox.vala
+++ b/src/ListBox.vala
@@ -61,7 +61,7 @@ public class ListBox : Gtk.ListBox {
     }
 
     private bool search_word_doesnt_match_any_in_list (string search_word, Bookmark[] bookmarks) {
-        int matchCount = 0;
+        int match_count = 0;
 
         if (search_word == "") {
             return false;
@@ -69,10 +69,10 @@ public class ListBox : Gtk.ListBox {
 
         foreach (Bookmark bookmark in bookmarks) {
             if (search_word in bookmark.get_name ()) {
-                matchCount++;
+                match_count++;
             }
         }
-        return matchCount == 0;
+        return match_count == 0;
     }
 }
 }

--- a/src/ListBoxRow.vala
+++ b/src/ListBoxRow.vala
@@ -91,8 +91,8 @@ public class ListBoxRow : Gtk.ListBoxRow {
             }
 
             try {
-                var terminalName = settings.get_string ("terminalname");
-                Process.spawn_command_line_async (terminalName + " --execute='" + ssh_command + "'");
+                var terminal_name = settings.get_string ("terminalname");
+                Process.spawn_command_line_async (terminal_name + " --execute='" + ssh_command + "'");
             } catch (SpawnError e) {
                 new Alert ("An error occured", e.message);
             }

--- a/src/StackManager.vala
+++ b/src/StackManager.vala
@@ -95,7 +95,7 @@ public class StackManager : Object {
 
         Gtk.ScrolledWindow result_box = new Gtk.ScrolledWindow (null, null);
         result_box.set_policy (Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
-        result_box.set_size_request (200,200);
+        result_box.set_size_request (200, 200);
         result_box.add (stack);
 
         pane.expand = true;
@@ -111,7 +111,7 @@ public class StackManager : Object {
     public void add_a_terminal () {
         Gtk.ScrolledWindow view_box = new Gtk.ScrolledWindow (null, null);
         view_box.set_policy (Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
-        view_box.set_size_request (700,200);
+        view_box.set_size_request (700, 200);
         view_box.add (terminal);
 
         pane.pack1 (view_box, true, false);


### PR DESCRIPTION
While working on a fix for #52, there were a handful of trailing-newlines, naming-convention and no-space errors from io.elementary.vala-lint during the git pre-commit hook. I corrected all those errors by fixing the whitespace and renaming variables to a snake case version. I checked each snake case version of the variable names to ensure that there would be no conflicts with existing variable names.